### PR TITLE
feat(cli): fallback open to xdg-open

### DIFF
--- a/kuma/kuma.go
+++ b/kuma/kuma.go
@@ -14,9 +14,16 @@ import (
 
 // Opens the dashboard in the default browser
 func (kuma *Kuma) Open() {
-	err := exec.Command("open", kuma.baseUrl+"/dashboard").Run()
+	url := kuma.baseUrl + "/dashboard"
+	opener := "xdg-open"
+
+	if _, err := exec.LookPath("open"); err == nil {
+		opener = "open"
+	}
+
+	err := exec.Command(opener, url).Run()
 	if err != nil {
-		fmt.Println("Failed to open URL:")
+		fmt.Println("Failed to open URL:", err)
 		os.Exit(1)
 	}
 }

--- a/kuma/types.go
+++ b/kuma/types.go
@@ -45,13 +45,13 @@ func ParseMonitorStatus(value string) (MonitorStatus, error) {
 type MonitorType string
 
 const (
-	HTTP  MonitorType = "http"
-	TCP   MonitorType = "port"
-	PUSH  MonitorType = "push"
-	GROUP MonitorType = "group"
-	PING  MonitorType = "ping"
-	KEYWORD   MonitorType = "keyword"
-	DNS   MonitorType = "dns"
+	HTTP    MonitorType = "http"
+	TCP     MonitorType = "port"
+	PUSH    MonitorType = "push"
+	GROUP   MonitorType = "group"
+	PING    MonitorType = "ping"
+	KEYWORD MonitorType = "keyword"
+	DNS     MonitorType = "dns"
 )
 
 func ParseMonitorType(value string) MonitorType {


### PR DESCRIPTION
`open` isn't available by default on Linux systems, so I changed the `kuma-waybar open` command to only select `open` if it is available in `PATH`, and otherwise fallback to `xdg-open` which should be available on most systems.